### PR TITLE
Fix skill duplication and drag slot update

### DIFF
--- a/Assets/Scripts/SkillDropSlot.cs
+++ b/Assets/Scripts/SkillDropSlot.cs
@@ -16,8 +16,7 @@ public class SkillDropSlot : MonoBehaviour, IDropHandler
         // evita mover para mesmo grupo
         if (wasActive == isActiveSlot) return;
 
+        // MoveSkill j atualiza HUD e stats
         SkillManager.Instance.MoveSkill(skill, isActiveSlot);
-        SkillManager.Instance.skillHUDController.UpdateHUD();
-        SkillManager.Instance.ReapplyBonuses();
     }
 }

--- a/Assets/Scripts/SkillManager.cs
+++ b/Assets/Scripts/SkillManager.cs
@@ -31,16 +31,20 @@ public class SkillManager : MonoBehaviour
     }
     public void AddSkill(SkillData skill)
     {
+        // procura em ambas as listas para evitar duplicacao
         var existing = activeSkills.Find(s => s.data == skill);
+        if (existing == null)
+            existing = reservedSkills.Find(s => s.data == skill);
 
+        // se ja possuir, apenas aumenta o nivel e reaplica bonus
         if (existing != null)
         {
             if (!existing.IsMaxLevel)
             {
                 existing.level++;
                 ReapplyBonuses();
-                skillHUDController.UpdateHUD();
             }
+            skillHUDController.UpdateHUD();
             return;
         }
 
@@ -58,12 +62,18 @@ public class SkillManager : MonoBehaviour
         if (moveToActive)
         {
             if (activeSkills.Count >= maxActiveSlots) return;
+
+            // remove possveis duplicatas
             reservedSkills.Remove(skill);
+            activeSkills.Remove(skill);
+
             activeSkills.Add(skill);
         }
         else
         {
             activeSkills.Remove(skill);
+            reservedSkills.Remove(skill);
+
             reservedSkills.Add(skill);
         }
 


### PR DESCRIPTION
## Summary
- prevent duplicate skills from being created when buying again
- update move logic to avoid double entries and always refresh HUD
- simplify drop slot handling since MoveSkill already updates the HUD

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643692842083229b84c8a6cd5c97f0