### PR TITLE
Fix health not resetting on skill purchase

### DIFF
--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -58,9 +58,8 @@ public class CharacterStats : MonoBehaviour
 
         isDead = true;
         Debug.Log($"{gameObject.name} morreu.");
-        // aqui você pode animar, desativar, destruir, etc.
+        currentHealth = Mathf.Min(currentHealth, maxHealth);
     }
-
     public virtual void UpdateHealth()
     {
         StartCoroutine(UpdateHealthWithDelay());

--- a/Assets/Scripts/Player/Player_Stats.cs
+++ b/Assets/Scripts/Player/Player_Stats.cs
@@ -12,10 +12,13 @@ public class Player_Stats : CharacterStats
 
     public void SetBonuses(int atk, int hp, int spd)
     {
+        bool healthChanged = bonusHealth != hp;
+
         bonusAttack = atk;
         bonusHealth = hp;
         bonusSpeed = spd;
 
-        UpdateHealth(); // atualiza vida caso maxHealth tenha mudado
+        if (healthChanged)
+            UpdateHealth(); // atualiza vida caso maxHealth tenha mudado
     }
 }


### PR DESCRIPTION
## Summary
- prevent `UpdateHealth` from resetting to full life
- only update health when bonuses change

## Testing
- `echo "No tests specified"`


------
https://chatgpt.com/codex/tasks/task_e_68644774f55083228d793b19f40a0287