### PR TITLE
Fix health not clamped when removing skill

### DIFF
--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -57,7 +57,7 @@ public class CharacterStats : MonoBehaviour
     private IEnumerator UpdateHealthWithDelay()
     {
         yield return new WaitForSeconds(0.001f);
-        currentHealth = maxHealth;
+        currentHealth = Mathf.Min(currentHealth, maxHealth);
         OnHealthChanged?.Invoke();
     }
 }


### PR DESCRIPTION
## Summary
- prevent current health from being reset to max when stats change

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_686453bf776c83228308043e93755300