### PR TITLE
Add gold management and skill costs

### DIFF
--- a/Assets/Data/SkillData/Passive_Damage.asset
+++ b/Assets/Data/SkillData/Passive_Damage.asset
@@ -20,4 +20,5 @@ MonoBehaviour:
   attackBonus: 10
   defenseBonus: 0
   speedBonus: 0
+  cost: 1
   maxLevel: 5

--- a/Assets/Data/SkillData/Passive_Health.asset
+++ b/Assets/Data/SkillData/Passive_Health.asset
@@ -21,4 +21,5 @@ MonoBehaviour:
   defenseBonus: 0
   speedBonus: 0
   healthBonus: 10
+  cost: 1
   maxLevel: 5

--- a/Assets/Data/SkillData/Passive_Speed.asset
+++ b/Assets/Data/SkillData/Passive_Speed.asset
@@ -21,4 +21,5 @@ MonoBehaviour:
   defenseBonus: 0
   speedBonus: 1
   healthBonus: 0
+  cost: 1
   maxLevel: 5

--- a/Assets/Prefabs/SkillHudSlotUI.prefab
+++ b/Assets/Prefabs/SkillHudSlotUI.prefab
@@ -65,6 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isActiveSlot: 0
   iconImage: {fileID: 44978940843808007}
+  bgImage: {fileID: 775843676934165881}
   levelText: {fileID: 917422039078735570}
   nameText: {fileID: 5023885912191492014}
 --- !u!114 &-3807611402447955116

--- a/Assets/Prefabs/SkillSlotUI.prefab
+++ b/Assets/Prefabs/SkillSlotUI.prefab
@@ -213,6 +213,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   iconImage: {fileID: 6227096480289852214}
+  backgroundImage: {fileID: 5360698553655788106}
   nameText: {fileID: 604092701500048744}
   descriptionText: {fileID: 3646509888716473291}
 --- !u!114 &2685200227091505709

--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -44,6 +44,7 @@ public class CharacterStats : MonoBehaviour
     {
         if (CompareTag("Enemy"))
             GameManager.Instance?.UnregisterEnemy(GetComponent<Enemy>());
+        GameManager.Instance?.AddGold(5);
 
         isDead = true;
         Debug.Log($"{gameObject.name} morreu.");

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -6,7 +7,9 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
-    [Header("Referências")]
+    [SerializeField] private int currentGold = 0;
+    public static event Action<int> OnGoldChanged;
+    [Header("ReferÃªncias")]
     public GameObject player;
     public List<Enemy> activeEnemies = new List<Enemy>();
 
@@ -59,7 +62,26 @@ public class GameManager : MonoBehaviour
             return;
         }
 
-        // Vitória se todos os inimigos estiverem mortos
+    public void AddGold(int amount)
+    {
+        currentGold += amount;
+        OnGoldChanged?.Invoke(currentGold);
+    }
+
+    public bool TrySpendGold(int amount)
+    {
+        if (currentGold >= amount)
+        {
+            currentGold -= amount;
+            OnGoldChanged?.Invoke(currentGold);
+            return true;
+        }
+        return false;
+    }
+
+    public int GetCurrentGold() => currentGold;
+
+        // VitÃ³ria se todos os inimigos estiverem mortos
         bool allDead = true;
         foreach (var enemy in activeEnemies)
         {
@@ -73,7 +95,7 @@ public class GameManager : MonoBehaviour
         if (allDead)
         {
             battleOngoing = false;
-            Debug.Log("VITÓRIA!");
+            Debug.Log("VITÃ“RIA!");
         }
     }
 }

--- a/Assets/Scripts/GoldDisplay.cs
+++ b/Assets/Scripts/GoldDisplay.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using TMPro;
+
+public class GoldDisplay : MonoBehaviour
+{
+    [SerializeField] private TextMeshProUGUI goldText;
+
+    private void Awake()
+    {
+        if (goldText == null)
+            goldText = GetComponent<TextMeshProUGUI>();
+        UpdateGold(GameManager.Instance ? GameManager.Instance.GetCurrentGold() : 0);
+    }
+
+    private void OnEnable()
+    {
+        GameManager.OnGoldChanged += UpdateGold;
+    }
+
+    private void OnDisable()
+    {
+        GameManager.OnGoldChanged -= UpdateGold;
+    }
+
+    private void UpdateGold(int value)
+    {
+        if (goldText != null)
+            goldText.text = value.ToString();
+    }
+}

--- a/Assets/Scripts/Skill/SkillData.cs
+++ b/Assets/Scripts/Skill/SkillData.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 
 public enum SkillType { Passive }
-public enum SkillRarity { Common, Rare, Epic, Legendary }
+public enum SkillRarity { Common, Uncommon, Rare, Epic, Legendary }
 
 [CreateAssetMenu(fileName = "NewSkill", menuName = "Skill")]
 public class SkillData : ScriptableObject
@@ -17,5 +17,22 @@ public class SkillData : ScriptableObject
     public int speedBonus;
     public int healthBonus;
 
+    public int cost;
+
     public int maxLevel = 5;
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        cost = rarity switch
+        {
+            SkillRarity.Common => 1,
+            SkillRarity.Uncommon => 2,
+            SkillRarity.Rare => 3,
+            SkillRarity.Epic => 4,
+            SkillRarity.Legendary => 5,
+            _ => cost
+        };
+    }
+#endif
 }

--- a/Assets/Scripts/Skill/SkillUIColor.cs
+++ b/Assets/Scripts/Skill/SkillUIColor.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+public static class SkillUIColor
+{
+    public static Color GetColor(SkillRarity rarity)
+    {
+        switch (rarity)
+        {
+            case SkillRarity.Common:
+                return Color.white;
+            case SkillRarity.Uncommon:
+                return Color.green;
+            case SkillRarity.Rare:
+                return Color.blue;
+            case SkillRarity.Epic:
+                return new Color(0.5f, 0f, 0.5f); // purple
+            case SkillRarity.Legendary:
+                return new Color(1f, 0.84f, 0f); // gold
+            default:
+                return Color.white;
+        }
+    }
+}

--- a/Assets/Scripts/SkillHudSlotUI.cs
+++ b/Assets/Scripts/SkillHudSlotUI.cs
@@ -5,6 +5,7 @@ using TMPro;
 public class SkillHudSlotUI : MonoBehaviour
 {
     [SerializeField] private Image iconImage;
+    [SerializeField] private Image bgImage;
     [SerializeField] private TextMeshProUGUI nameText;
     [SerializeField] private TextMeshProUGUI levelText;
 
@@ -17,6 +18,7 @@ public class SkillHudSlotUI : MonoBehaviour
         isActive = _isActive;
 
         if (iconImage) iconImage.sprite = instance.data.icon;
+        if (bgImage) bgImage.color = SkillUIColor.GetColor(instance.data.rarity);
         if (nameText) nameText.text = instance.data.skillName;
         if (levelText) levelText.text = "Lv. " + instance.level;
 

--- a/Assets/Scripts/SkillShopUI.cs
+++ b/Assets/Scripts/SkillShopUI.cs
@@ -36,12 +36,20 @@ public class SkillShopUI : MonoBehaviour
     {
         if (index >= 0 && index < currentShopSkills.Count)
         {
-            SkillManager.Instance.AddSkill(currentShopSkills[index]);
-            Debug.Log("Skill comprada: " + currentShopSkills[index].skillName);
+            var skill = currentShopSkills[index];
+            if (GameManager.Instance != null && GameManager.Instance.TrySpendGold(skill.cost))
+            {
+                SkillManager.Instance.AddSkill(skill);
+                Debug.Log("Skill comprada: " + skill.skillName);
 
-            skillSlots[index].Hide(); // <- esconde o slot visualmente
+                skillSlots[index].Hide(); // <- esconde o slot visualmente
 
-            SkillManager.Instance.skillHUDController.UpdateHUD(); // <- atualiza HUD de skills
+                SkillManager.Instance.skillHUDController.UpdateHUD(); // <- atualiza HUD de skills
+            }
+            else
+            {
+                Debug.Log("Gold insuficiente para comprar " + skill.skillName);
+            }
         }
     }
 
@@ -53,7 +61,7 @@ public class SkillShopUI : MonoBehaviour
         {
             SkillData selected = allPossibleSkills[Random.Range(0, allPossibleSkills.Count)];
 
-            // Garante que não apareça na loja se já estiver no nível 5
+            // Garante que nÃ£o apareÃ§a na loja se jÃ¡ estiver no nÃ­vel 5
             if (SkillManager.Instance.IsSkillMaxLevel(selected))
             {
                 i--;

--- a/Assets/Scripts/SkillSlotUI.cs
+++ b/Assets/Scripts/SkillSlotUI.cs
@@ -5,6 +5,7 @@ using TMPro;
 public class SkillSlotUI : MonoBehaviour
 {
     [SerializeField] private Image iconImage;
+    [SerializeField] private Image backgroundImage;
     [SerializeField] private TextMeshProUGUI nameText;
     [SerializeField] private TextMeshProUGUI descriptionText;
 
@@ -27,6 +28,9 @@ public class SkillSlotUI : MonoBehaviour
 
         if (iconImage != null)
             iconImage.sprite = skill.icon;
+
+        if (backgroundImage != null)
+            backgroundImage.color = SkillUIColor.GetColor(skill.rarity);
 
         if (nameText != null)
             nameText.text = skill.skillName;


### PR DESCRIPTION
## Summary
- implement gold management in `GameManager`
- award gold when enemies die
- assign costs and rarity colors for skills
- color skill slots based on rarity
- add shop validation for gold when buying
- display gold amount via new `GoldDisplay` script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68671d9393dc8322adbae44876abbc44