### PR TITLE
Implement player XP and level system

### DIFF
--- a/Assets/Scripts/ActiveSkillCountDisplay.cs
+++ b/Assets/Scripts/ActiveSkillCountDisplay.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using TMPro;
+
+public class ActiveSkillCountDisplay : MonoBehaviour
+{
+    [SerializeField] private TextMeshProUGUI countText;
+
+    private void Awake()
+    {
+        if (countText == null)
+            countText = GetComponent<TextMeshProUGUI>();
+    }
+
+    private void Update()
+    {
+        if (SkillManager.Instance == null || countText == null) return;
+        countText.text = $"{SkillManager.Instance.activeSkills.Count} / {SkillManager.Instance.maxActiveSlots}";
+    }
+}

--- a/Assets/Scripts/ActiveSkillCountDisplay.cs.meta
+++ b/Assets/Scripts/ActiveSkillCountDisplay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c79caddafb8946dcaf73cd68fb77a3c9

--- a/Assets/Scripts/BuyXPButton.cs
+++ b/Assets/Scripts/BuyXPButton.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BuyXPButton : MonoBehaviour
+{
+    [SerializeField] private int xpAmount = 1;
+    [SerializeField] private int goldCost = 1;
+
+    private Button button;
+
+    private void Awake()
+    {
+        button = GetComponent<Button>();
+        if (button != null)
+            button.onClick.AddListener(Buy);
+    }
+
+    private void Buy()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.BuyXP(xpAmount, goldCost);
+        }
+    }
+}

--- a/Assets/Scripts/BuyXPButton.cs.meta
+++ b/Assets/Scripts/BuyXPButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fdaa6f1590db4382b09913c8cee8528a

--- a/Assets/Scripts/LevelXPDisplay.cs
+++ b/Assets/Scripts/LevelXPDisplay.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using TMPro;
+
+public class LevelXPDisplay : MonoBehaviour
+{
+    [SerializeField] private TextMeshProUGUI displayText;
+
+    private void Awake()
+    {
+        if (displayText == null)
+            displayText = GetComponent<TextMeshProUGUI>();
+    }
+
+    private void OnEnable()
+    {
+        GameManager.OnXPChanged += UpdateDisplay;
+        GameManager.OnLevelUp += LevelUp;
+        UpdateDisplay(GameManager.Instance ? GameManager.Instance.playerLevel : 0,
+                      GameManager.Instance ? GameManager.Instance.playerXP : 0,
+                      GameManager.Instance ? GameManager.Instance.xpToNextLevel[Mathf.Clamp(GameManager.Instance.playerLevel,0,GameManager.Instance.xpToNextLevel.Length-1)] : 0);
+    }
+
+    private void OnDisable()
+    {
+        GameManager.OnXPChanged -= UpdateDisplay;
+        GameManager.OnLevelUp -= LevelUp;
+    }
+
+    private void LevelUp(int level)
+    {
+        UpdateDisplay(level,
+                      GameManager.Instance.playerXP,
+                      level < GameManager.Instance.xpToNextLevel.Length ? GameManager.Instance.xpToNextLevel[level] : 0);
+    }
+
+    private void UpdateDisplay(int level, int xp, int toNext)
+    {
+        if (displayText != null)
+        {
+            if (toNext <= 0) toNext = 0;
+            displayText.text = $"Level {level} — XP: {xp} / {toNext}";
+        }
+    }
+}

--- a/Assets/Scripts/LevelXPDisplay.cs.meta
+++ b/Assets/Scripts/LevelXPDisplay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d701fe1e50c448ab7725fcf4ab808e7


### PR DESCRIPTION
## Summary
- add XP and level variables to `GameManager`
- implement XP gain, buying XP, and leveling up
- expand `SkillShopUI` with rarity chances based on player level
- create UI helpers for showing level/XP, active skills slots, and a button to buy XP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869860ffd248322b6fd5b80cff1069a