### PR TITLE
Implement skill swapping on HUD

### DIFF
--- a/Assets/Scripts/SkillHudSlotUI.cs
+++ b/Assets/Scripts/SkillHudSlotUI.cs
@@ -1,8 +1,9 @@
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.EventSystems;
 
-public class SkillHudSlotUI : MonoBehaviour
+public class SkillHudSlotUI : MonoBehaviour, IDropHandler
 {
     [SerializeField] private Image iconImage;
     [SerializeField] private Image bgImage;
@@ -27,4 +28,15 @@ public class SkillHudSlotUI : MonoBehaviour
 
     public SkillInstance GetInstance() => instance;
     public bool IsActive() => isActive;
+
+    public void OnDrop(PointerEventData eventData)
+    {
+        var dragged = DraggedSkillSlot.draggedSlotUI;
+        if (dragged == null || dragged == this) return;
+
+        if (dragged.IsActive() != IsActive())
+        {
+            SkillManager.Instance.SwapSkills(dragged.GetInstance(), instance);
+        }
+    }
 }

--- a/Assets/Scripts/SkillManager.cs
+++ b/Assets/Scripts/SkillManager.cs
@@ -92,6 +92,35 @@ public class SkillManager : MonoBehaviour
         UIManager.Instance?.UpdateActiveSkillCount(); // Atualiza o contador de skills ativas no UIManager
     }
 
+    public void SwapSkills(SkillInstance first, SkillInstance second)
+    {
+        bool firstIsActive = activeSkills.Contains(first);
+        bool secondIsActive = activeSkills.Contains(second);
+
+        if (firstIsActive == secondIsActive) return;
+
+        if (firstIsActive)
+        {
+            activeSkills.Remove(first);
+            reservedSkills.Remove(second);
+
+            activeSkills.Add(second);
+            reservedSkills.Add(first);
+        }
+        else
+        {
+            reservedSkills.Remove(first);
+            activeSkills.Remove(second);
+
+            reservedSkills.Add(second);
+            activeSkills.Add(first);
+        }
+
+        ReapplyBonuses();
+        skillHUDController.UpdateHUD();
+        UIManager.Instance?.UpdateActiveSkillCount();
+    }
+
 
     public int GetSkillLevel(SkillData skill)
     {


### PR DESCRIPTION
## Summary
- implement swapping logic in `SkillManager`
- allow skill HUD slots to accept drops and trigger swaps

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_6869c3c5f6b08322af66a03e621cdc70