### PR TITLE
Update player death

### DIFF
--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -20,6 +20,16 @@ public class Enemy : MonoBehaviour
     public CharacterStats stats { get; private set; } // Reference to the enemy's stats
     public EnemyStateMachine stateMachine { get; private set; }
 
+    protected virtual void OnEnable()
+    {
+        GameManager.OnPlayerDeath += HandlePlayerDeath;
+    }
+
+    protected virtual void OnDisable()
+    {
+        GameManager.OnPlayerDeath -= HandlePlayerDeath;
+    }
+
     protected virtual void Awake()
     {
         stateMachine = new EnemyStateMachine();
@@ -41,6 +51,16 @@ public class Enemy : MonoBehaviour
     protected virtual void Update()
     {
 
+    }
+
+    private void HandlePlayerDeath()
+    {
+        OnPlayerDeath();
+    }
+
+    protected virtual void OnPlayerDeath()
+    {
+        // Overridden in derived classes to react to player death
     }
 
     public Vector3 GetPatrolDestination()

--- a/Assets/Scripts/Enemy/Enemy_Melee.cs
+++ b/Assets/Scripts/Enemy/Enemy_Melee.cs
@@ -38,4 +38,12 @@ public class Enemy_Melee : Enemy
     {
         stateMachine.ChangeState(deadState); // Change to dead state when the enemy dies
     }
+
+    protected override void OnPlayerDeath()
+    {
+        if (stats != null && stats.isDead) return;
+        agent.isStopped = true;
+        agent.ResetPath();
+        stateMachine.ChangeState(idleState);
+    }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,6 +7,8 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
+    public static event Action OnPlayerDeath; // Event fired when the player dies
+
     [SerializeField] private int currentGold = 0;
     public static event Action<int> OnGoldChanged;
 
@@ -21,6 +23,13 @@ public class GameManager : MonoBehaviour
     public List<Enemy> activeEnemies = new List<Enemy>();
 
     public bool battleOngoing = false;
+
+    public void PlayerDied()
+    {
+        battleOngoing = false; // stop battle loop
+        OnPlayerDeath?.Invoke();
+        player = null; // enemies no longer have a valid reference
+    }
 
     private void Awake()
     {

--- a/Assets/Scripts/Player/Player_Stats.cs
+++ b/Assets/Scripts/Player/Player_Stats.cs
@@ -36,5 +36,26 @@ public class Player_Stats : CharacterStats
     {
         base.Die();
         player.animator.SetTrigger("Death");
+        GameManager.Instance?.PlayerDied();
+        StartCoroutine(SinkAfterDelay());
+    }
+
+    [SerializeField] private float sinkDelay = 2f;
+    [SerializeField] private float sinkDistance = 2f;
+    [SerializeField] private float sinkDuration = 1.5f;
+
+    private IEnumerator SinkAfterDelay()
+    {
+        yield return new WaitForSeconds(sinkDelay);
+        Vector3 start = transform.position;
+        Vector3 end = start - new Vector3(0f, sinkDistance, 0f);
+        float elapsed = 0f;
+        while (elapsed < sinkDuration)
+        {
+            transform.position = Vector3.Lerp(start, end, elapsed / sinkDuration);
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        transform.position = end;
     }
 }


### PR DESCRIPTION
## Summary
- trigger `OnPlayerDeath` event in `GameManager`
- notify `GameManager` when the player dies and sink the body
- make enemies subscribe to `OnPlayerDeath`
- stop enemies when the player dies

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b07ad4fc08322b726dfc70748eefe