### PR TITLE
Refactor passive skill bonuses using Stat modifiers

### DIFF
--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -24,7 +24,7 @@ public class CharacterStats : MonoBehaviour
 
     public float maxHealth => baseMaxHealth + BonusHealth;
     public float attackDamage => baseAttackDamage + BonusAttack;
-    public float attackCooldown => Mathf.Max(0.2f, baseAttackCooldown - BonusSpeed * 0.1f);
+    public float attackCooldown => Mathf.Max(0.2f, baseAttackCooldown - offense.attackSpeed.GetValue() * 0.1f);
 
     public float currentHealth;
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -79,7 +79,9 @@ public class Enemy : MonoBehaviour
     {
         if (GameManager.Instance?.player != null)
         {
-            GameManager.Instance.player.GetComponent<CharacterStats>().TakeDamage(stats.attackDamage);
+            bool isCrit;
+            float damage = stats.GetDamage(out isCrit);
+            GameManager.Instance.player.GetComponent<CharacterStats>().TakeDamage(damage);
         }
     }
 

--- a/Assets/Scripts/Player/Player_Combat.cs
+++ b/Assets/Scripts/Player/Player_Combat.cs
@@ -82,11 +82,13 @@ public class Player_Combat : MonoBehaviour
     {
         if (currentTarget != null && !currentTarget.stats.isDead)
         {
-            currentTarget.stats.TakeDamage(stats.attackDamage);
+            bool isCrit;
+            float damage = stats.GetDamage(out isCrit);
+            currentTarget.stats.TakeDamage(damage);
         }
     }
 
-    // Chamado no final da animação se quiser resetar algo
+    // Chamado no final da animaÃ§Ã£o se quiser resetar algo
     public void OnAttackAnimationEnd()
     {
         // Pode ser usado para controlar combo, cooldowns, etc

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -139,16 +139,14 @@ public class SkillManager : MonoBehaviour
         var playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
         if (playerStats == null) return;
 
-        int totalAtk = 0, totalHp = 0, totalSpeed = 0;
+        foreach (var skill in activeSkills)
+            playerStats.RemoveSkillModifier(skill);
+
+        foreach (var skill in reservedSkills)
+            playerStats.RemoveSkillModifier(skill);
 
         foreach (var skill in activeSkills)
-        {
-            totalAtk += skill.data.attackBonus * skill.level;
-            totalHp += skill.data.healthBonus * skill.level;
-            totalSpeed += skill.data.speedBonus * skill.level;
-        }
-
-        playerStats.SetBonuses(totalAtk, totalHp, totalSpeed);
+            playerStats.ApplySkillModifier(skill);
     }
 
     public void OpenCloseShop()


### PR DESCRIPTION
## Summary
- remove SetBonuses approach in `Player_Stats`
- add methods to apply/remove stat modifiers per skill
- update `SkillManager` to use the new modifier API
- use `GetDamage` for player and enemy attacks
- drive attack cooldown from the new attack speed stat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be81e74888322ae50a4ee4fe705d3