### PR TITLE
Auto setup level buttons and pass battle scene data

### DIFF
--- a/Assets/Scripts/BattleManager.cs
+++ b/Assets/Scripts/BattleManager.cs
@@ -12,6 +12,10 @@ public class BattleManager : MonoBehaviour
     [SerializeField] private List<Transform> enemyDestinations = new List<Transform>();
     [SerializeField] private float countdownDuration = 5f;
 
+    public Transform PlayerEndPosition => playerDestination;
+    public Transform PlayerStartPosition => playerStartPos;
+    public List<Transform> EnemyDestinations => enemyDestinations;
+
     private void Awake()
     {
         if (Instance == null) Instance = this; else Destroy(gameObject);

--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -18,6 +18,7 @@ public class LevelManager : MonoBehaviour
 
     private int currentRound = 0;
     private int lives;
+    private int currentLevelIndex = -1;
 
     private void Awake()
     {
@@ -37,13 +38,20 @@ public class LevelManager : MonoBehaviour
         lives = startingLives;
         if (SceneManager.GetActiveScene().name == "BattleScene" && currentLevel != null)
         {
+            if (BattleManager.Instance != null)
+            {
+                playerSpawnPoint = BattleManager.Instance.PlayerStartPosition;
+                endPoint = BattleManager.Instance.PlayerEndPosition;
+                enemySpawnPoints = BattleManager.Instance.EnemyDestinations;
+            }
             StartCoroutine(LevelRoutine());
         }
     }
 
-    public void SetLevel(LevelData data)
+    public void SetLevel(LevelData data, int index = -1)
     {
         currentLevel = data;
+        currentLevelIndex = index;
     }
 
     private IEnumerator LevelRoutine()
@@ -72,6 +80,11 @@ public class LevelManager : MonoBehaviour
                 MovePlayerToEndPoint();
                 yield return new WaitForSeconds(5f);
             }
+        }
+
+        if (lives > 0 && currentLevelIndex >= 0)
+        {
+            ES3.Save($"LevelUnlocked_{currentLevelIndex + 1}", true);
         }
     }
 

--- a/Assets/Scripts/Level/LevelMenuManager.cs
+++ b/Assets/Scripts/Level/LevelMenuManager.cs
@@ -1,11 +1,30 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 
 public class LevelMenuManager : MonoBehaviour
 {
     [SerializeField] private List<LevelData> levels = new List<LevelData>();
+    [SerializeField] private List<Button> levelButtons = new List<Button>();
     [SerializeField] private string battleSceneName = "BattleScene";
+
+    private void Start()
+    {
+        SetupButtons();
+    }
+
+    private void SetupButtons()
+    {
+        for (int i = 0; i < levelButtons.Count && i < levels.Count; i++)
+        {
+            int index = i;
+            bool unlocked = ES3.Load<bool>($"LevelUnlocked_{index}", index == 0);
+            levelButtons[i].interactable = unlocked;
+            levelButtons[i].onClick.RemoveAllListeners();
+            levelButtons[i].onClick.AddListener(() => LoadLevel(index));
+        }
+    }
 
     public void LoadLevel(int index)
     {
@@ -14,7 +33,7 @@ public class LevelMenuManager : MonoBehaviour
 
         if (LevelManager.Instance != null)
         {
-            LevelManager.Instance.SetLevel(levels[index]);
+            LevelManager.Instance.SetLevel(levels[index], index);
         }
         SceneManager.LoadScene(battleSceneName);
     }


### PR DESCRIPTION
## Summary
- expose spawn and destination info from `BattleManager`
- feed `LevelManager` with spawn and enemy data from `BattleManager`
- record current level index and save unlock state when a level is finished
- auto assign level menu buttons and set them interactable depending on saved unlocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c363925f48322bf1e69e1ab79f794