### PR TITLE
Fix countdown reappearance and enemy spawn orientation

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -103,6 +103,7 @@ public class LevelManager : MonoBehaviour
 
     private IEnumerator CountdownRoutine()
     {
+        UIManager.Instance?.EnableCountdown();
         float timer = countdownDuration;
         while (timer > 0f)
         {
@@ -156,7 +157,11 @@ public class LevelManager : MonoBehaviour
         {
             if (round.enemies[i] == null) continue;
             Transform point = enemySpawnPoints[i];
-            Instantiate(round.enemies[i], point.position, point.rotation);
+            GameObject enemyObj = Instantiate(round.enemies[i], point.position, point.rotation);
+            if (GameManager.Instance.player != null)
+            {
+                enemyObj.transform.LookAt(GameManager.Instance.player.transform);
+            }
         }
     }
 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -96,6 +96,12 @@ public class UIManager : MonoBehaviour
         if (countdownText != null)
             countdownText.text = value.ToString();
     }
+
+    public void EnableCountdown()
+    {
+        if (countdownText != null)
+            countdownText.gameObject.SetActive(true);
+    }
     public void UpdateCountdownZero()
     {
         UpdateCountdown(0);


### PR DESCRIPTION
## Summary
- show countdown text when each countdown starts
- point enemies at the player when they spawn

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686c49656fa083228425092011ccc4a3