### PR TITLE
Fix health and rotation after round ends

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -78,6 +78,7 @@ public class LevelManager : MonoBehaviour
                 MovePlayerToEndPoint();
                 yield return new WaitUntil(() =>
                     Vector3.Distance(GameManager.Instance.player.transform.position, endPoint.position) < 0.1f);
+                GameManager.Instance.player.GetComponent<Player_Movement>().StopMovement();
                 FaceFirstEnemy();
             }
             else
@@ -110,10 +111,11 @@ public class LevelManager : MonoBehaviour
             else
             {
                 MovePlayerToEndPoint();
-                GameManager.Instance.player.GetComponent<CharacterStats>().currentHealth =
-                    GameManager.Instance.player.GetComponent<CharacterStats>().GetMaxHealth();
                 yield return new WaitUntil(() =>
                     Vector3.Distance(GameManager.Instance.player.transform.position, endPoint.position) < 0.1f);
+                GameManager.Instance.player.GetComponent<Player_Movement>().StopMovement();
+                GameManager.Instance.player.GetComponent<CharacterStats>().currentHealth =
+                    GameManager.Instance.player.GetComponent<CharacterStats>().GetMaxHealth();
                 FaceFirstEnemy();
                 yield return new WaitForSeconds(5f);
             }

--- a/Assets/Scripts/Player/Player_Stats.cs
+++ b/Assets/Scripts/Player/Player_Stats.cs
@@ -40,7 +40,11 @@ public class Player_Stats : CharacterStats
 
         if (skill.data.healthBonus != 0)
         {
+            float previousMax = GetMaxHealth();
+            bool wasFull = Mathf.Approximately(currentHealth, previousMax);
             resources.maxHealth.AddModifier(skill.data.healthBonus * skill.level, source);
+            if (wasFull)
+                currentHealth = GetMaxHealth();
             UpdateHealth();
         }
 


### PR DESCRIPTION
## Summary
- ensure player stops moving and faces enemies when reaching the end point
- refill player health after arrival
- keep current health in sync when max health increases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872fc30feb083229b19721bccaae11f