### PR TITLE
Fix player facing direction at end of round

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -241,9 +241,13 @@ public class LevelManager : MonoBehaviour
         if (GameManager.Instance.player == null) return;
         if (enemySpawnPoints.Count == 0) return;
         Transform lookTarget = enemySpawnPoints[0];
+        Vector3 direction = lookTarget.position - GameManager.Instance.player.transform.position;
+        if (direction.sqrMagnitude < 0.001f) return;
+
+        Quaternion lookRotation = Quaternion.LookRotation(direction);
+        Vector3 currentEuler = GameManager.Instance.player.transform.rotation.eulerAngles;
         GameManager.Instance.player.transform.rotation =
-            GameManager.Instance.player.GetComponent<Player>()
-                .FaceTarget(lookTarget.position);
+            Quaternion.Euler(currentEuler.x, lookRotation.eulerAngles.y, currentEuler.z);
     }
 
     private IEnumerator ReturnToMenuRoutine()


### PR DESCRIPTION
## Summary
- rotate player instantly toward the next enemy after reaching the EndPoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873cc0e29f88322a5c96f8d746ad0ef