### PR TITLE
Smooth player rotation at round end

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -94,6 +94,7 @@ public class LevelManager : MonoBehaviour
             UIManager.Instance?.UpdateRound(currentRound + 1, currentLevel.rounds.Count);
             yield return StartCoroutine(CountdownRoutine());
             GameManager.Instance?.StartBattle();
+            GameManager.Instance.player.GetComponent<Player_Movement>().StopFacingTarget();
             yield return new WaitUntil(() => GameManager.Instance.battleOngoing == false);
 
             bool playerDead = GameManager.Instance.player == null || GameManager.Instance.player.GetComponent<CharacterStats>().isDead;
@@ -241,13 +242,8 @@ public class LevelManager : MonoBehaviour
         if (GameManager.Instance.player == null) return;
         if (enemySpawnPoints.Count == 0) return;
         Transform lookTarget = enemySpawnPoints[0];
-        Vector3 direction = lookTarget.position - GameManager.Instance.player.transform.position;
-        if (direction.sqrMagnitude < 0.001f) return;
-
-        Quaternion lookRotation = Quaternion.LookRotation(direction);
-        Vector3 currentEuler = GameManager.Instance.player.transform.rotation.eulerAngles;
-        GameManager.Instance.player.transform.rotation =
-            Quaternion.Euler(currentEuler.x, lookRotation.eulerAngles.y, currentEuler.z);
+        var movement = GameManager.Instance.player.GetComponent<Player_Movement>();
+        movement.FaceTarget(lookTarget);
     }
 
     private IEnumerator ReturnToMenuRoutine()

--- a/Assets/Scripts/Player/Player_Movement.cs
+++ b/Assets/Scripts/Player/Player_Movement.cs
@@ -7,6 +7,8 @@ public class Player_Movement : MonoBehaviour
     private NavMeshAgent agent;
     private Transform currentTarget;
     private Player player;
+    private Transform lookTarget;
+    private bool facingTarget;
 
     private void Start()
     {
@@ -22,6 +24,11 @@ public class Player_Movement : MonoBehaviour
         if (currentTarget != null && !agent.isStopped && GameManager.Instance.battleOngoing == true)
         {
             agent.SetDestination(currentTarget.position);
+        }
+
+        if (facingTarget && lookTarget != null)
+        {
+            transform.rotation = player.FaceTarget(lookTarget.position);
         }
     }
 
@@ -43,6 +50,18 @@ public class Player_Movement : MonoBehaviour
     public bool IsMoving()
     {
         return agent.velocity.magnitude > 0.1f;
+    }
+
+    public void FaceTarget(Transform target)
+    {
+        lookTarget = target;
+        facingTarget = target != null;
+    }
+
+    public void StopFacingTarget()
+    {
+        lookTarget = null;
+        facingTarget = false;
     }
 
 }


### PR DESCRIPTION
## Summary
- add facing target logic to `Player_Movement`
- use that logic in `LevelManager.FaceFirstEnemy`
- stop facing the target when a round starts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873dbed676883228bd4fd2344b4a11e