### PR TITLE
Add skip countdown button

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -16,6 +16,8 @@ public class LevelManager : MonoBehaviour
     [SerializeField] private float countdownDuration = 5f;
     [SerializeField] private int startingLives = 3;
 
+    private bool skipCountdownRequested = false;
+
     private int currentRound = 0;
     private int lives;
     private int currentLevelIndex = -1;
@@ -46,6 +48,11 @@ public class LevelManager : MonoBehaviour
     private void Start()
     {
         lives = startingLives;
+    }
+
+    public void SkipCountdown()
+    {
+        skipCountdownRequested = true;
     }
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
@@ -139,13 +146,21 @@ public class LevelManager : MonoBehaviour
     private IEnumerator CountdownRoutine()
     {
         UIManager.Instance?.EnableCountdown();
+        UIManager.Instance?.ShowSkipCountdownButton(true);
         float timer = countdownDuration;
+        skipCountdownRequested = false;
         while (timer > 0f)
         {
+            if (skipCountdownRequested && timer > 1f)
+            {
+                timer = 1f;
+                skipCountdownRequested = false;
+            }
             UIManager.Instance?.UpdateCountdown(Mathf.CeilToInt(timer));
             timer -= Time.deltaTime;
             yield return null;
         }
+        UIManager.Instance?.ShowSkipCountdownButton(false);
         UIManager.Instance?.UpdateCountdownZero();
     }
 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -12,6 +12,9 @@ public class UIManager : MonoBehaviour
     [SerializeField] private int goldCost = 1;
     [SerializeField] private Button xpButton;
 
+    [Header("Skip Countdown Settings")]
+    [SerializeField] private Button skipCountdownButton;
+
     [Header("Active Skill Count")]
     [SerializeField] private TextMeshProUGUI activeSkillCountText;
 
@@ -31,6 +34,11 @@ public class UIManager : MonoBehaviour
 
         if (xpButton != null)
             xpButton.onClick.AddListener(BuyXpButtonFuction);
+
+        if (skipCountdownButton != null)
+            skipCountdownButton.onClick.AddListener(SkipCountdownFunction);
+
+        ShowSkipCountdownButton(false);
 
     }
     private void Start()
@@ -118,6 +126,17 @@ public class UIManager : MonoBehaviour
     {
         if (livesText != null)
             livesText.text = value.ToString();
+    }
+
+    private void SkipCountdownFunction()
+    {
+        LevelManager.Instance?.SkipCountdown();
+    }
+
+    public void ShowSkipCountdownButton(bool show)
+    {
+        if (skipCountdownButton != null)
+            skipCountdownButton.gameObject.SetActive(show);
     }
 
 }


### PR DESCRIPTION
## Summary
- add a new skip countdown button in `UIManager`
- allow `LevelManager` to process skip requests and show/hide the button during the countdown
- adjust countdown routine to cut remaining time to one second when skipped

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6873e3fbb6308322b8adb3670e6fb278