### PR TITLE
Repeat last round on death and delay enemy cleanup

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -111,12 +111,15 @@ public class LevelManager : MonoBehaviour
                 lives--;
                 UIManager.Instance?.UpdateLives(lives);
                 if (lives <= 0) yield break;
+                yield return new WaitForSeconds(3f);
                 RemoveRemainingEnemies();
-                yield return new WaitForSeconds(5f);
+                yield return new WaitForSeconds(2f);
                 RespawnPlayer();
                 yield return new WaitUntil(() =>
                     Vector3.Distance(GameManager.Instance.player.transform.position, endPoint.position) < 0.1f);
                 playerDiedLastRound = false;
+                if (currentRound == currentLevel.rounds.Count - 1)
+                    currentRound--;
             }
             else
             {


### PR DESCRIPTION
## Summary
- repeat the final round if the player dies and still has lives remaining
- keep enemies around for 3 seconds before removal after the player dies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fdcce9748322b79ec62a13c49efa