### PR TITLE
Update shop logic for max level skills

### DIFF
--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -81,6 +81,10 @@ public class LevelManager : MonoBehaviour
         for (currentRound = 0; currentRound < currentLevel.rounds.Count; currentRound++)
         {
             UIManager.Instance?.UpdateRound(currentRound + 1, currentLevel.rounds.Count);
+            if (currentRound > 0)
+            {
+                SkillManager.Instance?.skillShopUI?.RefreshShop();
+            }
             if (playerDiedLastRound || currentRound == 0)
             {
                 SpawnPlayer();

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -125,12 +125,16 @@ public class SkillManager : MonoBehaviour
     public int GetSkillLevel(SkillData skill)
     {
         var existing = activeSkills.Find(s => s.data == skill);
+        if (existing == null)
+            existing = reservedSkills.Find(s => s.data == skill);
         return existing?.level ?? 0;
     }
 
     public bool IsSkillMaxLevel(SkillData skill)
     {
         var existing = activeSkills.Find(s => s.data == skill);
+        if (existing == null)
+            existing = reservedSkills.Find(s => s.data == skill);
         return existing != null && existing.IsMaxLevel;
     }
 

--- a/Assets/Scripts/Skill/SkillShopUI.cs
+++ b/Assets/Scripts/Skill/SkillShopUI.cs
@@ -57,6 +57,10 @@ public class SkillShopUI : MonoBehaviour
         if (index >= 0 && index < currentShopSkills.Count)
         {
             var skill = currentShopSkills[index];
+
+            if (SkillManager.Instance != null && SkillManager.Instance.IsSkillMaxLevel(skill))
+                return; // skill already at max level
+
             if (GameManager.Instance != null && GameManager.Instance.TrySpendGold(skill.cost))
             {
                 SkillManager.Instance.AddSkill(skill);


### PR DESCRIPTION
## Summary
- prevent buying a skill if it's already at max level
- include reserved skills when checking current level
- refresh shop at the start of each new round (except the first)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687450e217208322a38fd2874945e584