### PR TITLE
Display star level in skill HUD

### DIFF
--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -37,6 +37,17 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler
         if (levelText) levelText.text = "Lv. " + instance.level;
         if (descriptionText) descriptionText.text = $"Increases {instance.data.description} by {skillValue}";
 
+        if (stars != null)
+        {
+            for (int i = 0; i < stars.Length; i++)
+            {
+                if (stars[i] != null)
+                {
+                    stars[i].SetActive(i < instance.level);
+                }
+            }
+        }
+
         GetComponent<SkillDragHandler>().Initialize(this);
     }
 


### PR DESCRIPTION
## Summary
- enable showing star icons as the skill level in `SkillHudSlotUI`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876f2da128c8322a1118133e280eb61