### PR TITLE
Add skill detail display and player stats HUD

### DIFF
--- a/Assets/Scripts/Skill/SkillDetailUI.cs
+++ b/Assets/Scripts/Skill/SkillDetailUI.cs
@@ -1,0 +1,84 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SkillDetailUI : MonoBehaviour
+{
+    public static SkillDetailUI Instance;
+
+    [SerializeField] private GameObject playerPanel;
+    [SerializeField] private GameObject skillPanel;
+
+    [Header("Skill UI")]
+    [SerializeField] private Image iconImage;
+    [SerializeField] private TextMeshProUGUI nameText;
+    [SerializeField] private TextMeshProUGUI levelText;
+    [SerializeField] private TextMeshProUGUI descriptionText;
+    [SerializeField] private GameObject[] stars;
+    [SerializeField] private Button sellButton;
+    [SerializeField] private Button backgroundButton;
+
+    private SkillInstance currentSkill;
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+        else Destroy(gameObject);
+
+        if (sellButton != null)
+            sellButton.onClick.AddListener(SellCurrentSkill);
+        if (backgroundButton != null)
+            backgroundButton.onClick.AddListener(Hide);
+    }
+
+    public void Show(SkillInstance skill)
+    {
+        currentSkill = skill;
+        if (playerPanel != null) playerPanel.SetActive(false);
+        if (skillPanel != null) skillPanel.SetActive(true);
+        UpdateUI(skill);
+    }
+
+    public void Hide()
+    {
+        if (skillPanel != null) skillPanel.SetActive(false);
+        if (playerPanel != null) playerPanel.SetActive(true);
+        currentSkill = null;
+    }
+
+    private void SellCurrentSkill()
+    {
+        if (currentSkill == null) return;
+        SkillManager.Instance?.SellSkill(currentSkill);
+        Hide();
+    }
+
+    private void UpdateUI(SkillInstance skill)
+    {
+        if (iconImage != null) iconImage.sprite = skill.data.icon;
+        if (nameText != null) nameText.text = skill.data.skillName;
+        if (levelText != null) levelText.text = "Lv. " + skill.level;
+
+        int value = 0;
+        if (skill.data.attackBonus != 0)
+            value = skill.data.attackBonus * skill.level;
+        else if (skill.data.defenseBonus != 0)
+            value = skill.data.defenseBonus * skill.level;
+        else if (skill.data.speedBonus != 0)
+            value = skill.data.speedBonus * skill.level;
+        else if (skill.data.healthBonus != 0)
+            value = skill.data.healthBonus * skill.level;
+
+        if (descriptionText != null)
+            descriptionText.text = $"Increases {skill.data.description} by {value}";
+
+        if (stars != null)
+        {
+            for (int i = 0; i < stars.Length; i++)
+            {
+                if (stars[i] != null)
+                    stars[i].SetActive(i < skill.level);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class SkillHudSlotUI : MonoBehaviour, IDropHandler
+public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
 {
     [SerializeField] private Image iconImage;
     [SerializeField] private Image bgImage;
@@ -71,5 +71,10 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler
         {
             SkillManager.Instance.SwapSkills(dragged.GetInstance(), instance);
         }
+    }
+
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        SkillDetailUI.Instance?.Show(instance);
     }
 }

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -138,6 +138,17 @@ public class SkillManager : MonoBehaviour
         return existing != null && existing.IsMaxLevel;
     }
 
+    public void SellSkill(SkillInstance skill)
+    {
+        if (activeSkills.Remove(skill) || reservedSkills.Remove(skill))
+        {
+            GameManager.Instance?.AddGold(skill.data.cost);
+            ReapplyBonuses();
+            skillHUDController.UpdateHUD();
+            UIManager.Instance?.UpdateActiveSkillCount();
+        }
+    }
+
     public void ReapplyBonuses()
     {
         var playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
@@ -151,6 +162,8 @@ public class SkillManager : MonoBehaviour
 
         foreach (var skill in activeSkills)
             playerStats.ApplySkillModifier(skill);
+
+        PlayerStatsHUD.Instance?.UpdateStats();
     }
 
     public void OpenCloseShop()

--- a/Assets/Scripts/UI/PlayerStatsHUD.cs
+++ b/Assets/Scripts/UI/PlayerStatsHUD.cs
@@ -1,0 +1,39 @@
+using TMPro;
+using UnityEngine;
+
+public class PlayerStatsHUD : MonoBehaviour
+{
+    public static PlayerStatsHUD Instance;
+
+    [SerializeField] private TextMeshProUGUI damageText;
+    [SerializeField] private TextMeshProUGUI attackSpeedText;
+    [SerializeField] private TextMeshProUGUI maxHealthText;
+
+    private Player_Stats playerStats;
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+        else Destroy(gameObject);
+    }
+
+    private void Start()
+    {
+        playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
+        UpdateStats();
+    }
+
+    public void UpdateStats()
+    {
+        if (playerStats == null)
+            playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
+        if (playerStats == null) return;
+
+        if (damageText != null)
+            damageText.text = playerStats.GetBaseDamage().ToString("F0");
+        if (attackSpeedText != null)
+            attackSpeedText.text = playerStats.offense.attackSpeed.GetValue().ToString("F1");
+        if (maxHealthText != null)
+            maxHealthText.text = playerStats.GetMaxHealth().ToString("F0");
+    }
+}


### PR DESCRIPTION
## Summary
- display player stats in a new HUD panel
- allow inspecting skills via SkillDetailUI
- add sell functionality to SkillManager
- open skill details when a skill HUD slot is clicked

## Testing
- `ls -R | grep -i test | head`
- `echo "No tests specified"`

------
https://chatgpt.com/codex/tasks/task_e_68795175fe248322bb28b9d2edca4cf6