### PR TITLE
Update skill detail UI interactions

### DIFF
--- a/Assets/Scripts/Skill/SkillDetailUI.cs
+++ b/Assets/Scripts/Skill/SkillDetailUI.cs
@@ -1,6 +1,8 @@
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using System.Collections.Generic;
 
 public class SkillDetailUI : MonoBehaviour
 {
@@ -12,11 +14,10 @@ public class SkillDetailUI : MonoBehaviour
     [Header("Skill UI")]
     [SerializeField] private Image iconImage;
     [SerializeField] private TextMeshProUGUI nameText;
-    [SerializeField] private TextMeshProUGUI levelText;
     [SerializeField] private TextMeshProUGUI descriptionText;
     [SerializeField] private GameObject[] stars;
     [SerializeField] private Button sellButton;
-    [SerializeField] private Button backgroundButton;
+    [SerializeField] private TextMeshProUGUI sellPriceText;
 
     private SkillInstance currentSkill;
 
@@ -27,8 +28,6 @@ public class SkillDetailUI : MonoBehaviour
 
         if (sellButton != null)
             sellButton.onClick.AddListener(SellCurrentSkill);
-        if (backgroundButton != null)
-            backgroundButton.onClick.AddListener(Hide);
     }
 
     public void Show(SkillInstance skill)
@@ -53,11 +52,31 @@ public class SkillDetailUI : MonoBehaviour
         Hide();
     }
 
+    private void Update()
+    {
+        if (skillPanel != null && skillPanel.activeSelf && Input.GetMouseButtonDown(0))
+        {
+            RectTransform rect = skillPanel.GetComponent<RectTransform>();
+            if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition, null))
+            {
+                // If clicking on another skill, it will reopen via its own handler
+                PointerEventData data = new PointerEventData(EventSystem.current) { position = Input.mousePosition };
+                List<RaycastResult> results = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(data, results);
+                foreach (var r in results)
+                {
+                    if (r.gameObject.GetComponent<SkillHudSlotUI>() != null)
+                        return;
+                }
+                Hide();
+            }
+        }
+    }
+
     private void UpdateUI(SkillInstance skill)
     {
         if (iconImage != null) iconImage.sprite = skill.data.icon;
         if (nameText != null) nameText.text = skill.data.skillName;
-        if (levelText != null) levelText.text = "Lv. " + skill.level;
 
         int value = 0;
         if (skill.data.attackBonus != 0)
@@ -71,6 +90,9 @@ public class SkillDetailUI : MonoBehaviour
 
         if (descriptionText != null)
             descriptionText.text = $"Increases {skill.data.description} by {value}";
+
+        if (sellPriceText != null)
+            sellPriceText.text = (skill.data.cost * skill.level).ToString();
 
         if (stars != null)
         {

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -142,7 +142,7 @@ public class SkillManager : MonoBehaviour
     {
         if (activeSkills.Remove(skill) || reservedSkills.Remove(skill))
         {
-            GameManager.Instance?.AddGold(skill.data.cost);
+            GameManager.Instance?.AddGold(skill.data.cost * skill.level);
             ReapplyBonuses();
             skillHUDController.UpdateHUD();
             UIManager.Instance?.UpdateActiveSkillCount();


### PR DESCRIPTION
## Summary
- allow closing the Skill Detail panel by clicking anywhere outside of it
- remove level text from Skill Detail UI and show sell value instead
- compute sell value based on total gold invested

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68795a37f170832292203a88fd5c0f1b