### PR TITLE
Fix player movement before battle

### DIFF
--- a/Assets/Scripts/Player/Player_Combat.cs
+++ b/Assets/Scripts/Player/Player_Combat.cs
@@ -30,7 +30,11 @@ public class Player_Combat : MonoBehaviour
 
     private void Update()
     {
-        if (stats.isDead || GameManager.Instance == null) return;
+        if (stats.isDead || GameManager.Instance == null)
+            return;
+
+        if (!GameManager.Instance.battleOngoing)
+            return;
 
         attackTimer += Time.deltaTime;
 

--- a/Assets/Scripts/Player/Player_Movement.cs
+++ b/Assets/Scripts/Player/Player_Movement.cs
@@ -33,6 +33,11 @@ public class Player_Movement : MonoBehaviour
     public void SetTarget(Transform target)
     {
         currentTarget = target;
+        if (currentTarget != null)
+        {
+            agent.destination = currentTarget.position;
+            agent.SearchPath();
+        }
     }
 
     public void StopMovement()
@@ -43,6 +48,10 @@ public class Player_Movement : MonoBehaviour
     public void ResumeMovement()
     {
         agent.isStopped = false;
+        if (currentTarget != null)
+        {
+            agent.SearchPath();
+        }
     }
 
     public bool IsMoving()


### PR DESCRIPTION
## Summary
- prevent player combat script from updating until battle has started

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687aae4e0f848322b5984f54dfa0739e