### PR TITLE
Implement active skills via SkillData

### DIFF
--- a/Assets/Scripts/Player/PlayerAnimationEvents.cs
+++ b/Assets/Scripts/Player/PlayerAnimationEvents.cs
@@ -4,11 +4,13 @@ public class PlayerAnimationEvents : MonoBehaviour
 {
     private Player player;
     private Player_Combat combat;
+    private Player_Skills skills;
 
     private void Start()
     {
         player = GetComponentInParent<Player>();
         combat = GetComponentInParent<Player_Combat>();
+        skills = GetComponentInParent<Player_Skills>();
     }
 
     public void AttackHitOnEnemy()
@@ -23,10 +25,11 @@ public class PlayerAnimationEvents : MonoBehaviour
 
     public void SkillEffect()
     {
+        skills?.ActivateSlashSkill();
     }
 
     public void SkillAnimationEffectEnd()
     {
-
+        // reserved for future use
     }
 }

--- a/Assets/Scripts/Player/Player_Skills.cs
+++ b/Assets/Scripts/Player/Player_Skills.cs
@@ -1,39 +1,42 @@
-using System.Collections;
 using UnityEngine;
 
 public class Player_Skills : MonoBehaviour
 {
-    [SerializeField] private GameObject slashSkill;
+    [SerializeField] private SkillData slashSkillData;
+    private SwordSlashSkill slashSkill;
 
-    private void Update()
+    private Player player;
+
+    private void Awake()
     {
-        if(Input.GetKeyDown(KeyCode.J))
+        player = GetComponent<Player>();
+        if (slashSkillData != null && slashSkillData.activeSkillPrefab != null)
         {
-            ActivateSlashSkill();
+            var obj = Instantiate(slashSkillData.activeSkillPrefab, transform);
+            slashSkill = obj.GetComponent<SwordSlashSkill>();
+            slashSkill?.Configure(slashSkillData);
         }
     }
 
-    private void ActiveOrDesactiveSkill(GameObject skill, bool activeOrDesactive)
+    private void Update()
     {
-        if(skill == null)
+        if (Input.GetKeyDown(KeyCode.J))
         {
-            Debug.LogWarning("Skill is null, cannot activate.");
-            return;
+            TryUseSlashSkill();
         }
+    }
 
-        skill.SetActive(activeOrDesactive);
+    private void TryUseSlashSkill()
+    {
+        if (slashSkill == null || slashSkill.IsOnCooldown)
+            return;
+
+        if (player != null)
+            player.animator.SetTrigger("SkillSlash01");
     }
 
     public void ActivateSlashSkill()
     {
-        StartCoroutine(ActiveSlashSkillCo());
+        slashSkill?.TryUse();
     }
-
-    private IEnumerator ActiveSlashSkillCo()
-    {
-        ActiveOrDesactiveSkill(slashSkill, true);
-        yield return new WaitForSeconds(1f); // Adjust the duration as needed
-        ActiveOrDesactiveSkill(slashSkill, false);
-    }
-
 }

--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using UnityEngine;
+
+public abstract class ActiveSkill : MonoBehaviour
+{
+    [SerializeField] protected SkillData skillData;
+    [SerializeField] protected float cooldown = 1f;
+    [SerializeField] protected float duration = 0.5f;
+    [SerializeField] protected float damageMultiplier = 1f;
+
+    protected Player owner;
+    protected bool isActive;
+    private float nextReadyTime;
+
+    public SkillData Data => skillData;
+
+    public void Configure(SkillData data)
+    {
+        skillData = data;
+        if (skillData != null && skillData.type == SkillType.Active)
+        {
+            cooldown = skillData.activeCooldown;
+            duration = skillData.activeDuration;
+            damageMultiplier = skillData.activeDamageMultiplier;
+        }
+    }
+
+    protected virtual void Awake()
+    {
+        owner = GetComponentInParent<Player>();
+        if (skillData != null && skillData.type == SkillType.Active)
+        {
+            cooldown = skillData.activeCooldown;
+            duration = skillData.activeDuration;
+            damageMultiplier = skillData.activeDamageMultiplier;
+        }
+        gameObject.SetActive(false);
+    }
+
+    public bool IsOnCooldown => Time.time < nextReadyTime;
+
+    public void TryUse()
+    {
+        if (!IsOnCooldown)
+            StartCoroutine(UseCoroutine());
+    }
+
+    private IEnumerator UseCoroutine()
+    {
+        isActive = true;
+        gameObject.SetActive(true);
+        OnActivate();
+        nextReadyTime = Time.time + cooldown;
+        yield return new WaitForSeconds(duration);
+        gameObject.SetActive(false);
+        isActive = false;
+        OnDeactivate();
+    }
+
+    protected virtual void OnActivate() {}
+    protected virtual void OnDeactivate() {}
+
+    protected float CalculateDamage()
+    {
+        if (owner == null) return 0f;
+        bool crit;
+        return owner.Stats.GetDamage(out crit, damageMultiplier);
+    }
+}

--- a/Assets/Scripts/Skill/ActiveSkill.cs.meta
+++ b/Assets/Scripts/Skill/ActiveSkill.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bb537fd009e04dedb478136a23d098a6

--- a/Assets/Scripts/Skill/SkillData.cs
+++ b/Assets/Scripts/Skill/SkillData.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public enum SkillType { Passive }
+public enum SkillType { Passive, Active }
 public enum SkillRarity { Common, Uncommon, Rare, Epic, Legendary }
 
 [CreateAssetMenu(fileName = "NewSkill", menuName = "Skill")]
@@ -20,6 +20,12 @@ public class SkillData : ScriptableObject
     public int cost;
 
     public int maxLevel = 5;
+
+    // Active skill specific properties
+    public GameObject activeSkillPrefab;
+    public float activeCooldown = 1f;
+    public float activeDuration = 0.5f;
+    public float activeDamageMultiplier = 1f;
 
 #if UNITY_EDITOR
     private void OnValidate()

--- a/Assets/Scripts/Skill/SwordSlashSkill.cs
+++ b/Assets/Scripts/Skill/SwordSlashSkill.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+public class SwordSlashSkill : ActiveSkill
+{
+    [SerializeField] private BoxCollider hitBox;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        if (hitBox == null)
+            hitBox = GetComponent<BoxCollider>();
+        if (hitBox != null)
+            hitBox.isTrigger = true;
+    }
+
+    protected override void OnActivate()
+    {
+        // VFX is played when the GameObject becomes active
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!isActive) return;
+
+        if (!other.CompareTag("Enemy"))
+            return;
+
+        var stats = other.GetComponent<CharacterStats>();
+        if (stats != null && !stats.isDead)
+        {
+            float dmg = CalculateDamage();
+            stats.TakeDamage(dmg);
+        }
+    }
+}

--- a/Assets/Scripts/Skill/SwordSlashSkill.cs.meta
+++ b/Assets/Scripts/Skill/SwordSlashSkill.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bdf99f17cf3d439a8da5674dc016499d


### PR DESCRIPTION
## Summary
- extend `SkillType` enum and `SkillData` with active skill info
- allow `ActiveSkill` to be configured from `SkillData`
- spawn and configure `SwordSlashSkill` from its data in `Player_Skills`
- detect enemies by tag so the slash can hit multiple targets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d1995b9f0832286d4dab939469e0b