### PR TITLE
Update slash skill to support multiple targets

### DIFF
--- a/Assets/Scripts/Player/Player_Skills.cs
+++ b/Assets/Scripts/Player/Player_Skills.cs
@@ -1,14 +1,22 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 public class Player_Skills : MonoBehaviour
 {
-    [SerializeField] private SwordSlashSkill slashSkill;
+    [SerializeField] private SkillData slashSkillData;
+    [SerializeField] private ActiveSkill[] skillReferences;
+    private readonly Dictionary<SkillData, ActiveSkill> skillLookup = new();
 
     private Player player;
 
     private void Awake()
     {
         player = GetComponent<Player>();
+        foreach (var skill in skillReferences)
+        {
+            if (skill != null && skill.Data != null && !skillLookup.ContainsKey(skill.Data))
+                skillLookup.Add(skill.Data, skill);
+        }
     }
 
     private void Update()
@@ -21,7 +29,7 @@ public class Player_Skills : MonoBehaviour
 
     private void TryUseSlashSkill()
     {
-        if (slashSkill == null || slashSkill.IsOnCooldown)
+        if (!skillLookup.TryGetValue(slashSkillData, out var skill) || skill.IsOnCooldown)
             return;
 
         if (player != null)
@@ -30,6 +38,7 @@ public class Player_Skills : MonoBehaviour
 
     public void ActivateSlashSkill()
     {
-        slashSkill?.TryUse();
+        if (skillLookup.TryGetValue(slashSkillData, out var skill))
+            skill.TryUse();
     }
 }

--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -6,6 +6,7 @@ public abstract class ActiveSkill : MonoBehaviour
     [SerializeField] protected float cooldown = 1f;
     [SerializeField] protected float duration = 0.5f;
     [SerializeField] protected float damageMultiplier = 1f;
+    [SerializeField] private SkillData data;
 
     protected Player owner;
     protected bool isActive;
@@ -17,6 +18,7 @@ public abstract class ActiveSkill : MonoBehaviour
         gameObject.SetActive(false);
     }
 
+    public SkillData Data => data;
     public bool IsOnCooldown => Time.time < nextReadyTime;
 
     public void TryUse()

--- a/Assets/Scripts/Skill/SkillData.cs
+++ b/Assets/Scripts/Skill/SkillData.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public enum SkillType { Passive }
+public enum SkillType { Passive, Active }
 public enum SkillRarity { Common, Uncommon, Rare, Epic, Legendary }
 
 [CreateAssetMenu(fileName = "NewSkill", menuName = "Skill")]
@@ -20,6 +20,8 @@ public class SkillData : ScriptableObject
     public int cost;
 
     public int maxLevel = 5;
+
+    public ActiveSkill activeSkill;
 
 #if UNITY_EDITOR
     private void OnValidate()

--- a/Assets/Scripts/Skill/SwordSlashSkill.cs
+++ b/Assets/Scripts/Skill/SwordSlashSkill.cs
@@ -1,8 +1,10 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 public class SwordSlashSkill : ActiveSkill
 {
     [SerializeField] private BoxCollider hitBox;
+    private readonly HashSet<Enemy> enemiesHit = new();
 
     protected override void Awake()
     {
@@ -15,17 +17,22 @@ public class SwordSlashSkill : ActiveSkill
 
     protected override void OnActivate()
     {
+        enemiesHit.Clear();
         // VFX is played when the GameObject becomes active
     }
 
     private void OnTriggerEnter(Collider other)
     {
         if (!isActive) return;
-        var enemy = other.GetComponent<Enemy>();
-        if (enemy != null && !enemy.stats.isDead)
+
+        if (!other.CompareTag("Enemy")) return;
+
+        var enemy = other.GetComponentInParent<Enemy>();
+        if (enemy != null && !enemy.stats.isDead && !enemiesHit.Contains(enemy))
         {
             float dmg = CalculateDamage();
             enemy.stats.TakeDamage(dmg);
+            enemiesHit.Add(enemy);
         }
     }
 }


### PR DESCRIPTION
## Summary
- support multiple enemies in `SwordSlashSkill`
- add `SkillData.activeSkill` and new `Active` skill type
- expose `SkillData` reference in `ActiveSkill`
- map skills via `SkillData` in `Player_Skills`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d29141c188322a03287f6ef67e39a