### PR TITLE
Prioritize active skills before attacks

### DIFF
--- a/Assets/Scripts/Player/PlayerAnimationEvents.cs
+++ b/Assets/Scripts/Player/PlayerAnimationEvents.cs
@@ -25,11 +25,11 @@ public class PlayerAnimationEvents : MonoBehaviour
 
     public void SkillEffect()
     {
-        skills?.ActivateSlashSkill();
+        skills?.ActivatePendingSkill();
     }
 
     public void SkillAnimationEffectEnd()
     {
-        // reserved for future use
+        combat.IsAttackingEnd();
     }
 }

--- a/Assets/Scripts/Player/Player_Combat.cs
+++ b/Assets/Scripts/Player/Player_Combat.cs
@@ -10,6 +10,7 @@ public class Player_Combat : MonoBehaviour
     private CharacterStats stats;
     private Player_Movement movement;
     private Player player;
+    private Player_Skills skills;
     private RichAI agent;
     private bool isAttacking = false;
 
@@ -28,6 +29,7 @@ public class Player_Combat : MonoBehaviour
         stats = GetComponent<CharacterStats>();
         movement = GetComponent<Player_Movement>();
         player = GetComponent<Player>();
+        skills = GetComponent<Player_Skills>();
     }
 
     private void Update()
@@ -81,9 +83,13 @@ public class Player_Combat : MonoBehaviour
             if (attackTimer >= stats.attackCooldown && isAttacking == false)
             {
                 attackTimer = 0;
-                StartAttackAnimation();
+                bool usedSkill = skills != null && skills.TryUseNextActiveSkill(currentTarget, attackRange);
+                if (!usedSkill)
+                {
+                    StartAttackAnimation();
+                }
                 isAttacking = true;
-                player.animator.SetBool("IsAttacking", true);   
+                player.animator.SetBool("IsAttacking", true);
             }
         }
         else

--- a/Assets/Scripts/Player/Player_Skills.cs
+++ b/Assets/Scripts/Player/Player_Skills.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 public class Player_Skills : MonoBehaviour
 {
-    [SerializeField] private SkillData slashSkillData;
     [SerializeField] private ActiveSkill[] skillReferences;
     private readonly Dictionary<SkillData, ActiveSkill> skillLookup = new();
 
     private Player player;
+    private ActiveSkill pendingSkill;
 
     private void Awake()
     {
@@ -19,26 +19,39 @@ public class Player_Skills : MonoBehaviour
         }
     }
 
-    private void Update()
+    public bool TryUseNextActiveSkill(Enemy target, float defaultRange)
     {
-        if (Input.GetKeyDown(KeyCode.J))
+        if (SkillManager.Instance == null || target == null) return false;
+
+        foreach (var instance in SkillManager.Instance.activeSkills)
         {
-            TryUseSlashSkill();
+            if (!skillLookup.TryGetValue(instance.data, out var skill))
+                continue;
+
+            if (skill.IsOnCooldown)
+                continue;
+
+            float range = skill.Range > 0 ? skill.Range : defaultRange;
+
+            if (Vector3.Distance(transform.position, target.transform.position) > range)
+                continue;
+
+            pendingSkill = skill;
+
+            if (!string.IsNullOrEmpty(skill.AnimationTrigger))
+                player.animator.SetTrigger(skill.AnimationTrigger);
+            else
+                pendingSkill.TryUse();
+
+            return true;
         }
+
+        return false;
     }
 
-    private void TryUseSlashSkill()
+    public void ActivatePendingSkill()
     {
-        if (!skillLookup.TryGetValue(slashSkillData, out var skill) || skill.IsOnCooldown)
-            return;
-
-        if (player != null)
-            player.animator.SetTrigger("SkillSlash01");
-    }
-
-    public void ActivateSlashSkill()
-    {
-        if (skillLookup.TryGetValue(slashSkillData, out var skill))
-            skill.TryUse();
+        pendingSkill?.TryUse();
+        pendingSkill = null;
     }
 }

--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -6,6 +6,8 @@ public abstract class ActiveSkill : MonoBehaviour
     [SerializeField] protected float cooldown = 1f;
     [SerializeField] protected float duration = 0.5f;
     [SerializeField] protected float damageMultiplier = 1f;
+    [SerializeField] protected float activationRange = 1.5f;
+    [SerializeField] protected string animationTrigger = "";
     [SerializeField] private SkillData data;
 
     protected Player owner;
@@ -19,6 +21,8 @@ public abstract class ActiveSkill : MonoBehaviour
     }
 
     public SkillData Data => data;
+    public float Range => activationRange;
+    public string AnimationTrigger => animationTrigger;
     public bool IsOnCooldown => Time.time < nextReadyTime;
 
     public void TryUse()

--- a/Assets/Scripts/Skill/SwordSlashSkill.cs
+++ b/Assets/Scripts/Skill/SwordSlashSkill.cs
@@ -35,4 +35,10 @@ public class SwordSlashSkill : ActiveSkill
             enemiesHit.Add(enemy);
         }
     }
+
+    private void Reset()
+    {
+        activationRange = 1.5f;
+        animationTrigger = "SkillSlash01";
+    }
 }


### PR DESCRIPTION
## Summary
- add range/animation trigger support to `ActiveSkill`
- generalize player skill handling
- trigger skills before normal attacks
- finalize skill animations in events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d474264748322bdb318e8552cade9