### PR TITLE
Show cooldown on skill HUD

### DIFF
--- a/Assets/Scripts/Player/Player_Skills.cs
+++ b/Assets/Scripts/Player/Player_Skills.cs
@@ -59,4 +59,10 @@ public class Player_Skills : MonoBehaviour
         pendingSkill?.TryUse();
         pendingSkill = null;
     }
+
+    public ActiveSkill GetActiveSkill(SkillData data)
+    {
+        skillLookup.TryGetValue(data, out var skill);
+        return skill;
+    }
 }

--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -26,6 +26,8 @@ public abstract class ActiveSkill : MonoBehaviour
     public float Range => activationRange;
     public string AnimationTrigger => animationTrigger;
     public bool IsOnCooldown => Time.time < nextReadyTime;
+    public float CooldownRemaining => Mathf.Max(0f, nextReadyTime - Time.time);
+    public float CooldownDuration => cooldown;
 
     public void SetOwner(Player player) => owner = player;
 

--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -12,6 +12,7 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
     [SerializeField] private TextMeshProUGUI descriptionText;
     [SerializeField] private GameObject cooldownGameObject;
     private TextMeshProUGUI cooldownText;
+    private ActiveSkill activeSkill;
 
     [SerializeField] private GameObject[] stars;
 
@@ -22,6 +23,22 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
     {
         instance = _instance;
         isActive = _isActive;
+
+        if (cooldownGameObject != null)
+            cooldownText = cooldownGameObject.GetComponentInChildren<TextMeshProUGUI>();
+
+        activeSkill = null;
+
+        bool showCooldown = instance.data.type == SkillType.Active;
+        if (cooldownGameObject != null)
+            cooldownGameObject.SetActive(showCooldown);
+
+        if (showCooldown && GameManager.Instance != null && GameManager.Instance.player != null)
+        {
+            var skills = GameManager.Instance.player.GetComponent<Player_Skills>();
+            if (skills != null)
+                activeSkill = skills.GetActiveSkill(instance.data);
+        }
 
         int skillValue = 0;
 
@@ -80,5 +97,23 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
     {
         SkillDetailUI.Instance?.Show(instance);
         Debug.Log("Clicked on skill: " + instance.data.skillName);
+    }
+
+    private void Update()
+    {
+        if (activeSkill == null || cooldownText == null || cooldownGameObject == null)
+            return;
+
+        float remaining = activeSkill.CooldownRemaining;
+        if (remaining > 0f)
+        {
+            if (!cooldownGameObject.activeSelf)
+                cooldownGameObject.SetActive(true);
+            cooldownText.text = Mathf.CeilToInt(remaining).ToString();
+        }
+        else if (cooldownGameObject.activeSelf)
+        {
+            cooldownGameObject.SetActive(false);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add cooldown accessors to `ActiveSkill`
- expose skill lookup via `Player_Skills`
- update `SkillHudSlotUI` to display cooldown countdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d605d97e48322bf9df74b2094a356