### PR TITLE
Fix skill execution logic

### DIFF
--- a/Assets/Scripts/Player/Player_Combat.cs
+++ b/Assets/Scripts/Player/Player_Combat.cs
@@ -80,14 +80,23 @@ public class Player_Combat : MonoBehaviour
         {
             movement.StopMovement();
 
-            if (attackTimer >= stats.attackCooldown && isAttacking == false)
+            if (!isAttacking)
             {
-                attackTimer = 0;
+                // Use any available skill immediately when in range.
                 bool usedSkill = skills != null && skills.TryUseNextActiveSkill(currentTarget, attackRange);
-                if (!usedSkill)
+                if (usedSkill)
                 {
-                    StartAttackAnimation();
+                    attackTimer = 0f;
+                    isAttacking = true;
+                    player.animator.SetBool("IsAttacking", true);
+                    return;
                 }
+            }
+
+            if (attackTimer >= stats.attackCooldown && !isAttacking)
+            {
+                attackTimer = 0f;
+                StartAttackAnimation();
                 isAttacking = true;
                 player.animator.SetBool("IsAttacking", true);
             }

--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -33,23 +33,19 @@ public abstract class ActiveSkill : MonoBehaviour
 
     public void TryUse()
     {
-        if (!IsOnCooldown)
-        {
-            // Start the coroutine from the owner so it works even when this
-            // GameObject is disabled.
-            if (owner != null)
-                owner.StartCoroutine(UseCoroutine());
-            // Start the coroutine from an active object so it works even when
-            // this GameObject is disabled.
-            MonoBehaviour runner = owner != null
-                ? owner as MonoBehaviour
-                : SkillManager.Instance as MonoBehaviour;
+        if (IsOnCooldown)
+            return;
 
-            if (runner != null)
-                runner.StartCoroutine(UseCoroutine());
-            else
-                StartCoroutine(UseCoroutine());
-        }
+        // Select a MonoBehaviour to run the coroutine. Prefer the owner, but
+        // fall back to the SkillManager or this component if necessary.
+        MonoBehaviour runner = owner != null
+            ? owner as MonoBehaviour
+            : SkillManager.Instance as MonoBehaviour;
+
+        if (runner == null)
+            runner = this;
+
+        runner.StartCoroutine(UseCoroutine());
     }
 
     private IEnumerator UseCoroutine()


### PR DESCRIPTION
## Summary
- ensure ActiveSkill coroutine runs only once
- prioritize active skills when in range so they trigger before normal attacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d678b6e64832282d43be78d151b24