### PR TITLE
Adjust icon color on cooldown

### DIFF
--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -110,10 +110,15 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
             if (!cooldownGameObject.activeSelf)
                 cooldownGameObject.SetActive(true);
             cooldownText.text = Mathf.CeilToInt(remaining).ToString();
+            if (iconImage != null)
+                iconImage.color = Color.gray;
         }
-        else if (cooldownGameObject.activeSelf)
+        else
         {
-            cooldownGameObject.SetActive(false);
+            if (cooldownGameObject.activeSelf)
+                cooldownGameObject.SetActive(false);
+            if (iconImage != null)
+                iconImage.color = Color.white;
         }
     }
 }


### PR DESCRIPTION
## Summary
- show grey skill icon while active skill is cooling down

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d708f05a88322a69461bbae6f93d5