### PR TITLE
Fix skill effect reference and skill initialization

### DIFF
--- a/Assets/Scripts/Player/PlayerAnimationEvents.cs
+++ b/Assets/Scripts/Player/PlayerAnimationEvents.cs
@@ -25,6 +25,9 @@ public class PlayerAnimationEvents : MonoBehaviour
 
     public void SkillEffect()
     {
+        if (skills == null)
+            skills = GetComponentInParent<Player_Skills>();
+
         skills?.ActivatePendingSkill();
     }
 

--- a/Assets/Scripts/Player/Player_Skills.cs
+++ b/Assets/Scripts/Player/Player_Skills.cs
@@ -14,13 +14,15 @@ public class Player_Skills : MonoBehaviour
         player = GetComponent<Player>();
         foreach (var skill in skillReferences)
         {
-            if (skill != null && skill.Data != null && !skillLookup.ContainsKey(skill.Data))
-                if (skill == null) continue;
+            if (skill == null)
+                continue;
 
             skill.SetOwner(player);
 
-            if (skill.Data != null && !skillLookup.ContainsKey(skill.Data))
-                skillLookup.Add(skill.Data, skill);
+            if (skill.Data == null || skillLookup.ContainsKey(skill.Data))
+                continue;
+
+            skillLookup.Add(skill.Data, skill);
         }
     }
 


### PR DESCRIPTION
## Summary
- refresh player skills reference before calling `ActivatePendingSkill`
- validate skills list on awake to register valid skills only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d7d30ade083229f1419ee30f80209