### PR TITLE
Resolve first-time activation bug in ActiveSkill

### DIFF
--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -36,6 +36,11 @@ public abstract class ActiveSkill : MonoBehaviour
         if (IsOnCooldown)
             return;
 
+        // Ensure the skill object is active before starting the coroutine.
+        // This avoids issues with coroutines on disabled objects on the first use.
+        if (!gameObject.activeSelf)
+            gameObject.SetActive(true);
+
         // Select a MonoBehaviour to run the coroutine. Prefer the owner, but
         // fall back to the SkillManager or this component if necessary.
         MonoBehaviour runner = owner != null
@@ -52,7 +57,6 @@ public abstract class ActiveSkill : MonoBehaviour
     private IEnumerator UseCoroutine()
     {
         Debug.Log("Coroutine chamada no ActiveSkill");
-        gameObject.SetActive(true);
         isActive = true;
         OnActivate();
         nextReadyTime = Time.time + cooldown;


### PR DESCRIPTION
## Summary
- ensure skill objects activate before running the coroutine
- remove redundant activation inside `UseCoroutine`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d85d0a71c8322bff844703ab8a1b4