### PR TITLE
Fix skill priority before normal attacks

### DIFF
--- a/Assets/Scripts/Player/Player_Combat.cs
+++ b/Assets/Scripts/Player/Player_Combat.cs
@@ -76,22 +76,24 @@ public class Player_Combat : MonoBehaviour
         movement.SetTarget(currentTarget.transform);
         player.transform.rotation = player.FaceTarget(currentTarget.transform.position);
 
+        // Always attempt to use a skill first when possible.
+        if (!isAttacking)
+        {
+            bool usedSkill = skills != null &&
+                skills.TryUseNextActiveSkill(currentTarget, attackRange);
+            if (usedSkill)
+            {
+                movement.StopMovement();
+                attackTimer = 0f;
+                isAttacking = true;
+                player.animator.SetBool("IsAttacking", true);
+                return;
+            }
+        }
+
         if (distance <= attackRange)
         {
             movement.StopMovement();
-
-            if (!isAttacking)
-            {
-                // Use any available skill immediately when in range.
-                bool usedSkill = skills != null && skills.TryUseNextActiveSkill(currentTarget, attackRange);
-                if (usedSkill)
-                {
-                    attackTimer = 0f;
-                    isAttacking = true;
-                    player.animator.SetBool("IsAttacking", true);
-                    return;
-                }
-            }
 
             if (attackTimer >= stats.attackCooldown && !isAttacking)
             {


### PR DESCRIPTION
## Summary
- prioritize active skill usage in `Player_Combat.TryAttack`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d899d89fc832298a6c392444bf239