### PR TITLE
Block drag when skill on cooldown

### DIFF
--- a/Assets/Scripts/Skill/SkillDragHandler.cs
+++ b/Assets/Scripts/Skill/SkillDragHandler.cs
@@ -7,6 +7,8 @@ public class SkillDragHandler : MonoBehaviour, IBeginDragHandler, IEndDragHandle
     private RectTransform rectTransform;
     private CanvasGroup canvasGroup;
     private Transform originalParent;
+    private SkillHudSlotUI slot;
+    private bool canDrag;
 
     private void Awake()
     {
@@ -16,12 +18,20 @@ public class SkillDragHandler : MonoBehaviour, IBeginDragHandler, IEndDragHandle
 
     public void Initialize(SkillHudSlotUI slot)
     {
+        this.slot = slot;
         DraggedSkillSlot.draggedSlotUI = null; // sempre limpa antes
     }
 
     public void OnBeginDrag(PointerEventData eventData)
     {
-        DraggedSkillSlot.draggedSlotUI = GetComponent<SkillHudSlotUI>();
+        if (slot != null && slot.IsOnCooldown())
+        {
+            canDrag = false;
+            return;
+        }
+
+        canDrag = true;
+        DraggedSkillSlot.draggedSlotUI = slot;
         canvasGroup.blocksRaycasts = false;
         originalParent = transform.parent;
         transform.SetParent(transform.root);
@@ -30,11 +40,17 @@ public class SkillDragHandler : MonoBehaviour, IBeginDragHandler, IEndDragHandle
 
     public void OnDrag(PointerEventData eventData)
     {
+        if (!canDrag)
+            return;
+
         rectTransform.anchoredPosition += eventData.delta / transform.root.GetComponent<Canvas>().scaleFactor;
     }
 
     public void OnEndDrag(PointerEventData eventData)
     {
+        if (!canDrag)
+            return;
+
         DraggedSkillSlot.draggedSlotUI = null;
         canvasGroup.blocksRaycasts = true;
         transform.SetParent(originalParent);

--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -81,6 +81,7 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
 
     public SkillInstance GetInstance() => instance;
     public bool IsActive() => isActive;
+    public bool IsOnCooldown() => activeSkill != null && activeSkill.IsOnCooldown;
 
     public void OnDrop(PointerEventData eventData)
     {


### PR DESCRIPTION
## Summary
- prevent dragging a skill slot while the skill is on cooldown
- expose cooldown state from `SkillHudSlotUI`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e41be6b808322a949d86d1d43406b