### PR TITLE
Allow swapping skills within containers

### DIFF
--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -88,10 +88,7 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
         var dragged = DraggedSkillSlot.draggedSlotUI;
         if (dragged == null || dragged == this) return;
 
-        if (dragged.IsActive() != IsActive())
-        {
-            SkillManager.Instance.SwapSkills(dragged.GetInstance(), instance);
-        }
+        SkillManager.Instance.SwapSkills(dragged.GetInstance(), instance);
     }
 
     public void OnPointerDown(PointerEventData eventData)

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -97,23 +97,45 @@ public class SkillManager : MonoBehaviour
         bool firstIsActive = activeSkills.Contains(first);
         bool secondIsActive = activeSkills.Contains(second);
 
-        if (firstIsActive == secondIsActive) return;
-
-        if (firstIsActive)
+        // Same container: simply swap their positions
+        if (firstIsActive && secondIsActive)
         {
-            activeSkills.Remove(first);
-            reservedSkills.Remove(second);
-
-            activeSkills.Add(second);
-            reservedSkills.Add(first);
+            int index1 = activeSkills.IndexOf(first);
+            int index2 = activeSkills.IndexOf(second);
+            if (index1 >= 0 && index2 >= 0)
+            {
+                activeSkills[index1] = second;
+                activeSkills[index2] = first;
+            }
         }
-        else
+        else if (!firstIsActive && !secondIsActive)
         {
-            reservedSkills.Remove(first);
-            activeSkills.Remove(second);
+            int index1 = reservedSkills.IndexOf(first);
+            int index2 = reservedSkills.IndexOf(second);
+            if (index1 >= 0 && index2 >= 0)
+            {
+                reservedSkills[index1] = second;
+                reservedSkills[index2] = first;
+            }
+        }
+        else // different containers: swap between lists
+        {
+            if (firstIsActive)
+            {
+                activeSkills.Remove(first);
+                reservedSkills.Remove(second);
 
-            reservedSkills.Add(second);
-            activeSkills.Add(first);
+                activeSkills.Add(second);
+                reservedSkills.Add(first);
+            }
+            else
+            {
+                reservedSkills.Remove(first);
+                activeSkills.Remove(second);
+
+                reservedSkills.Add(second);
+                activeSkills.Add(first);
+            }
         }
 
         ReapplyBonuses();


### PR DESCRIPTION
## Summary
- allow swapping skills inside active and reserve containers
- update drag/drop handler to use new logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e4bdd4d18832298612c987da849fa