### PR TITLE
Handle drag-and-drop reorder on same skill container

### DIFF
--- a/Assets/Scripts/Skill/SkillDropSlot.cs
+++ b/Assets/Scripts/Skill/SkillDropSlot.cs
@@ -13,10 +13,18 @@ public class SkillDropSlot : MonoBehaviour, IDropHandler
         var skill = dragged.GetInstance();
         var wasActive = dragged.IsActive();
 
-        // evita mover para mesmo grupo
-        if (wasActive == isActiveSlot) return;
+        // se soltar no mesmo container, move para o final da lista
+        if (wasActive == isActiveSlot)
+        {
+            var list = wasActive ? SkillManager.Instance.activeSkills : SkillManager.Instance.reservedSkills;
+            if (list.Remove(skill))
+                list.Add(skill);
 
-        // MoveSkill j atualiza HUD e stats
+            SkillManager.Instance.skillHUDController.UpdateHUD();
+            return;
+        }
+
+        // MoveSkill já atualiza HUD e stats
         SkillManager.Instance.MoveSkill(skill, isActiveSlot);
     }
 }


### PR DESCRIPTION
## Summary
- tweak SkillDropSlot drop handler
- if a skill is dropped back onto its original container (not on another skill) it now moves to the end of the list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e5053382c8322968cf4187668a1c0