### PR TITLE
Add hit FX event and pooling

### DIFF
--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class CharacterStats : MonoBehaviour
 {
     public static Action OnHealthChanged;
+    public event Action OnHit;
 
     public Stat_ResourceGroup resources;
     public Stat_OffenseGroup offense;
@@ -41,6 +42,7 @@ public class CharacterStats : MonoBehaviour
         }
 
         currentHealth -= _damage;
+        OnHit?.Invoke();
         if (currentHealth <= 0)
         {
             currentHealth = 0;

--- a/Assets/Scripts/Enemy/Enemy_FX.cs
+++ b/Assets/Scripts/Enemy/Enemy_FX.cs
@@ -2,15 +2,31 @@ using UnityEngine;
 
 public class Enemy_FX : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    [SerializeField] private Transform hitFxPosition;
+    private CharacterStats stats;
+
+    private void Awake()
     {
-        
+        stats = GetComponent<CharacterStats>();
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnEnable()
     {
-        
+        if (stats != null)
+            stats.OnHit += PlayHitFx;
+    }
+
+    private void OnDisable()
+    {
+        if (stats != null)
+            stats.OnHit -= PlayHitFx;
+    }
+
+    private void PlayHitFx()
+    {
+        if (hitFxPosition == null || HitFxManager.instance == null)
+            return;
+
+        HitFxManager.instance.PlayHitFx(hitFxPosition.position, hitFxPosition.rotation);
     }
 }

--- a/Assets/Scripts/HitFxManager.cs
+++ b/Assets/Scripts/HitFxManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections;
 
 public class HitFxManager : MonoBehaviour
 {
@@ -20,5 +21,22 @@ public class HitFxManager : MonoBehaviour
     private void Start()
     {
         Pooler = GetComponent<ObjectPooler>();
+    }
+
+    public void PlayHitFx(Vector3 position, Quaternion rotation)
+    {
+        if (Pooler == null) return;
+
+        GameObject fx = Pooler.GetInstanceFromPool();
+        fx.transform.SetPositionAndRotation(position, rotation);
+        fx.SetActive(true);
+
+        var ps = fx.GetComponent<ParticleSystem>();
+        float delay = 1f;
+        if (ps != null)
+        {
+            delay = ps.main.duration;
+        }
+        StartCoroutine(ObjectPooler.ReturnToPoolWithDelay(fx, delay));
     }
 }

--- a/Assets/Scripts/Player/Player_FX.cs
+++ b/Assets/Scripts/Player/Player_FX.cs
@@ -2,15 +2,31 @@ using UnityEngine;
 
 public class Player_FX : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    [SerializeField] private Transform hitFxPosition;
+    private CharacterStats stats;
+
+    private void Awake()
     {
-        
+        stats = GetComponent<CharacterStats>();
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnEnable()
     {
-        
+        if (stats != null)
+            stats.OnHit += PlayHitFx;
+    }
+
+    private void OnDisable()
+    {
+        if (stats != null)
+            stats.OnHit -= PlayHitFx;
+    }
+
+    private void PlayHitFx()
+    {
+        if (hitFxPosition == null || HitFxManager.instance == null)
+            return;
+
+        HitFxManager.instance.PlayHitFx(hitFxPosition.position, hitFxPosition.rotation);
     }
 }


### PR DESCRIPTION
## Summary
- allow `CharacterStats` to emit an `OnHit` event whenever damage is taken
- add `PlayHitFx` pooling helper in `HitFxManager`
- create `Player_FX` and `Enemy_FX` scripts to spawn hit VFX when `OnHit` fires

## Testing
- `grep -R "Test" -n Assets/Scripts | head`

------
https://chatgpt.com/codex/tasks/task_e_687e610490a48322aed029ecad072a5e