### PR TITLE
Show active skill damage in HUD

### DIFF
--- a/Assets/Scripts/Skill/ActiveSkill.cs
+++ b/Assets/Scripts/Skill/ActiveSkill.cs
@@ -28,6 +28,7 @@ public abstract class ActiveSkill : MonoBehaviour
     public bool IsOnCooldown => Time.time < nextReadyTime;
     public float CooldownRemaining => Mathf.Max(0f, nextReadyTime - Time.time);
     public float CooldownDuration => cooldown;
+    public float[] DamageMultipliers => damageMultipliers;
 
     public void SetOwner(Player player) => owner = player;
 

--- a/Assets/Scripts/Skill/SkillHudSlotUI.cs
+++ b/Assets/Scripts/Skill/SkillHudSlotUI.cs
@@ -55,7 +55,24 @@ public class SkillHudSlotUI : MonoBehaviour, IDropHandler, IPointerDownHandler
         if (bgImage) bgImage.color = SkillUIColor.GetColor(instance.data.rarity);
         if (nameText) nameText.text = instance.data.skillName;
         if (levelText) levelText.text = "Lv. " + instance.level;
-        if (descriptionText) descriptionText.text = $"Increases {instance.data.description} by {skillValue}";
+
+        if (descriptionText)
+        {
+            if (instance.data.type == SkillType.Active)
+            {
+                float percent = 100f;
+                if (activeSkill != null && activeSkill.DamageMultipliers != null && activeSkill.DamageMultipliers.Length > 0)
+                {
+                    int idx = Mathf.Clamp(instance.level - 1, 0, activeSkill.DamageMultipliers.Length - 1);
+                    percent = activeSkill.DamageMultipliers[idx] * 100f;
+                }
+                descriptionText.text = $"Deals {percent}% {instance.data.description}";
+            }
+            else
+            {
+                descriptionText.text = $"Increases {instance.data.description} by {skillValue}";
+            }
+        }
 
         if (stars != null)
         {


### PR DESCRIPTION
## Summary
- expose damage multiplier array from `ActiveSkill`
- adjust skill HUD description to include active skill damage percent when applicable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eb25a51a08322b13590757d5828d2