### PR TITLE
Fix skill bonus reapplication preserving health ratio

### DIFF
--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -176,6 +176,8 @@ public class SkillManager : MonoBehaviour
         var playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
         if (playerStats == null) return;
 
+        float healthRatio = playerStats.currentHealth / playerStats.GetMaxHealth();
+
         foreach (var skill in activeSkills)
             playerStats.RemoveSkillModifier(skill);
 
@@ -184,6 +186,9 @@ public class SkillManager : MonoBehaviour
 
         foreach (var skill in activeSkills)
             playerStats.ApplySkillModifier(skill);
+
+        playerStats.currentHealth = Mathf.Clamp(playerStats.GetMaxHealth() * healthRatio, 0, playerStats.GetMaxHealth());
+        playerStats.UpdateHealth();
 
         PlayerStatsHUD.Instance?.UpdateStats();
     }


### PR DESCRIPTION
## Summary
- prevent skill repositioning from healing the player by tracking health ratio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fb9cd2a808322a4b10ffdebac20a8