### PR TITLE
Fix skill sell not reverting health bonus

### DIFF
--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -162,8 +162,13 @@ public class SkillManager : MonoBehaviour
 
     public void SellSkill(SkillInstance skill)
     {
+        var playerStats = GameManager.Instance?.player?.GetComponent<Player_Stats>();
+
         if (activeSkills.Remove(skill) || reservedSkills.Remove(skill))
         {
+            // Remove the modifiers granted by this skill from the player stats
+            playerStats?.RemoveSkillModifier(skill);
+
             GameManager.Instance?.AddGold(skill.data.cost * skill.level);
             ReapplyBonuses();
             skillHUDController.UpdateHUD();


### PR DESCRIPTION
## Summary
- fix player max health not updating when a skill with health bonus is sold

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ffeb130308322bf3b9233edaa3dad