### PR TITLE
Toggle Animator root motion when idle

### DIFF
--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -26,17 +26,24 @@ public class Player : MonoBehaviour
         }
 
         UpdateAnimations();
+        UpdateRootMotion();
     }
 
     private void UpdateAnimations()
     {
         bool isMoving = movement.IsMoving();
 
-        // Só muda o bool se ele for diferente do valor atual
+        // SÃ³ muda o bool se ele for diferente do valor atual
         if (animator.GetBool("IsWalking") != isMoving)
         {
             animator.SetBool("IsWalking", isMoving);
         }
+    }
+
+    private void UpdateRootMotion()
+    {
+        bool isIdle = !animator.GetBool("IsWalking") && !animator.GetBool("IsAttacking");
+        animator.applyRootMotion = isIdle;
     }
 
     public void PlayAttack()


### PR DESCRIPTION
## Summary
- enable root motion only while the player is idle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688001ad2e148322a8b8406e0eb9d23f